### PR TITLE
Use 'isSliceArrayView' to determine if an array is an alias

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -798,7 +798,7 @@ module ChapelDistribution {
   // that arr.eltType is meaningful.
   proc _delete_arr(arr, param privatized:bool) {
     // decide whether or not the array is an alias
-    var isalias = (arr._arrAlias != nil);
+    var isalias = (arr._arrAlias != nil) || arr.isSliceArrayView();
 
     // array implementation can destroy data or other members
     arr.dsiDestroyArr(isalias);


### PR DESCRIPTION
Resolves failures for miniMD (local with DefaultRectangular).