### PR TITLE
Fix dsiSlice compilation errors.

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1930,17 +1930,7 @@ proc BlockArr.doiBulkTransferToDR(Barg)
           writeln("A[",r1,"] = B[",r2,"]");
       
         const d ={(...r1)};
-        halt("Wanting to call dsiSlice");
-        /*
-        const slice = B.dsiSlice(d._value);
-        //Necessary to calculate the value of blk variable in DR
-        //with the new domain r1
-        slice.adjustBlkOffStrForNewDomain(d._value, slice);
-        
-        slice.doiBulkTransferStride(A.locArr[j].myElems[(...r2)]._value);
-        
-        delete slice;
-        */
+        Barg[(...r1)] = A.locArr[j].myElems[(...r2)];
       }
     }
 }
@@ -1976,17 +1966,7 @@ proc BlockArr.doiBulkTransferFromDR(Barg)
         if debugBlockDistBulkTransfer then
           writeln("A[",r2,"] = B[",r1,"]");
           
-        const d ={(...r1)};
-        halt("Wanting to call dsiSlice");
-        /*
-        const slice = B.dsiSlice(d._value);
-        //this step it's necessary to calculate the value of blk variable in DR
-        //with the new domain r1
-        slice.adjustBlkOffStrForNewDomain(d._value, slice);
-        
-        A.locArr[j].myElems[(...r2)]._value.doiBulkTransferStride(slice);
-        delete slice;
-        */
+        A.locArr[j].myElems[(...r2)] = Barg[(...r1)];
       }
     }
 }

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1306,17 +1306,10 @@ proc CyclicArr.doiBulkTransferToDR(Barg)
             r1[t] = (ini[t]:el..end[t]:el by (end[t] - ini[t]):el/(r2[t].length-1));
         }
             
-        const d ={(...r1)};
-        const slice = B.dsiSlice(d._value);
-        //Necessary to calculate the value of blk variable in DR
-        //with the new domain r1
-        slice.adjustBlkOffStrForNewDomain(d._value, slice);
-     
         if debugCyclicDistBulkTransfer then 
           writeln(" A[",(...r1),"] = B[",(...r2), "]");
-      
-        slice.doiBulkTransferStride(A.locArr[j].myElems[(...r2)]._value);
-        delete slice;
+
+        Barg[(...r1)] = A.locArr[j].myElems[(...r2)];
       }
     }
 }
@@ -1353,15 +1346,8 @@ proc CyclicArr.doiBulkTransferFromDR(Barg)
         
         if debugCyclicDistBulkTransfer then
             writeln("A[",(...r2),"] = B[",(...r1), "] ");
-        
-        const d ={(...r1)};
-        const slice = B.dsiSlice(d._value);
-        //this step it's necessary to calculate the value of blk variable in DR
-        //with the new domain r1
-        slice.adjustBlkOffStrForNewDomain(d._value, slice);
-      
-        A.locArr[j].myElems[(...r2)]._value.doiBulkTransferStride(slice);
-        delete slice;
+
+        A.locArr[j].myElems[(...r2)] = Barg[(...r1)];
       }
     }
 }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -2075,15 +2075,7 @@ proc StencilArr.doiBulkTransferToDR(Barg)
         if debugStencilDistBulkTransfer then
           writeln("A[",r1,"] = B[",r2,"]");
       
-        const d ={(...r1)};
-        const slice = B.dsiSlice(d._value);
-        //Necessary to calculate the value of blk variable in DR
-        //with the new domain r1
-        slice.adjustBlkOffStrForNewDomain(d._value, slice);
-        
-        slice.doiBulkTransferStride(A.locArr[j].myElems[(...r2)]._value);
-        
-        delete slice;
+        Barg[(...r1)] = A.locArr[j].myElems[(...r2)];
       }
     }
 }
@@ -2118,15 +2110,8 @@ proc StencilArr.doiBulkTransferFromDR(Barg)
         
         if debugStencilDistBulkTransfer then
           writeln("A[",r2,"] = B[",r1,"]");
-          
-        const d ={(...r1)};
-        const slice = B.dsiSlice(d._value);
-        //this step it's necessary to calculate the value of blk variable in DR
-        //with the new domain r1
-        slice.adjustBlkOffStrForNewDomain(d._value, slice);
-        
-        A.locArr[j].myElems[(...r2)]._value.doiBulkTransferStride(slice);
-        delete slice;
+
+        A.locArr[j].myElems[(...r2)] = Barg[(...r1)];
       }
     }
 }


### PR DESCRIPTION
Use normal slicing instead of dsiSlice in distributed bulk-transfer functions. This changes passes for optimizations/bulkcomm/{alberto,asenjo} for --local.