### PR TITLE
Improved support for StencilDist in ArrayViews world

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3646,8 +3646,8 @@ module ChapelArray {
     // conditional plus halt as a workaround, though to date, the halt
     // has not actually been triggered.
     //
-    if a._value.isSliceArrayView() {
-      halt("Trying to replaceWithDeepCopy() on an array slice");
+    if a._instance.type != b._instance.type {
+      halt("Mismatching types in chpl_replaceWithDeepCopy");
     } else {
       a._instance = b._instance;  // array classes don't match if 'a' was a slice
     }

--- a/test/distributions/bharshbarg/stencil/slice.chpl
+++ b/test/distributions/bharshbarg/stencil/slice.chpl
@@ -91,7 +91,7 @@ proc test(dom : domain) {
         var temp = if isTuple(idx) then idx else (idx,);
         // Look at indices that should be in the cache, but are not in the
         // periodic region.
-        if !sub.member(idx) && Space.member(idx) {
+        if !sub.member(idx) && dom.member(idx) {
           var m = 1;
           for i in temp do m *= i;
           assert(Actual[idx] == m);


### PR DESCRIPTION
- Fix dsiMember to return 'true' for indices in the fluff region
- Modify check in chpl_replaceWithDeepCopy to check if _instance types
  match
- Add 'checkBounds' method to ArrayViewSlice and use it in dsiAccess
- Create the ref/const-ref/value variants of dsiAccess
- Thread a param called 'ignoreFluff' through the Stencil classes in
  order to support a fluff-less view of the array.