### PR TITLE
Turn chpl__unalias into a returning function

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -541,18 +541,18 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
 {
   SET_LINENO(moveExpr);
 
-  Expr*     lhs      = moveExpr->get(1);
+  Expr*     lhs       = moveExpr->get(1);
 
-  CallExpr* callExpr = toCallExpr(moveExpr->get(2));
-  FnSymbol* fn       = callExpr->isResolved();
+  CallExpr* callExpr  = toCallExpr(moveExpr->get(2));
+  FnSymbol* fn        = callExpr->isResolved();
 
-  Expr*     nextExpr = moveExpr->next;
-  CallExpr* copyExpr = NULL;
+  Expr*     nextExpr  = moveExpr->next;
+  CallExpr* copyExpr  = NULL;
 
-  Symbol*   useLhs   = toSymExpr(lhs)->symbol();
-  Symbol*   refVar   = newTemp("ret_to_arg_ref_tmp_", useLhs->type->refType);
+  Symbol*   useLhs    = toSymExpr(lhs)->symbol();
+  Symbol*   refVar    = newTemp("ret_to_arg_ref_tmp_", useLhs->type->refType);
 
-  FnSymbol* unaliasFn = getUnalias(useLhs->type);
+  FnSymbol* unaliasFn = NULL;
 
   // Make sure that we created a temp with a type
   INT_ASSERT(useLhs->type->refType);
@@ -583,6 +583,9 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
             Type*      formalType = formalArg->type;
             Type*      actualType = rhsCall->get(1)->getValType();
             Type*      returnType = rhsFn->retType->getValType();
+
+            unaliasFn = getUnalias(useLhs->type);
+
             // Cannot reduce initCopy/autoCopy when types differ (unless there
             //   is an unaliasFn available)
             // Cannot reduce initCopy/autoCopy for sync variables
@@ -613,26 +616,22 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
   if (copyExpr) {
     FnSymbol* rhsFn = copyExpr->isResolved();
 
-    copyExpr->replace(copyExpr->get(1)->remove());
-
-    // But... if we're replacing an init copy, we got to a user
-    // variable, so add an unalias call if there is one
-    if (rhsFn->hasFlag(FLAG_INIT_COPY_FN)) {
-      if (unaliasFn) {
-        VarSymbol* unaliasTemp = newTemp("unaliasTemp", unaliasFn->retType);
-        callExpr->insertBefore(new DefExpr(unaliasTemp));
-        callExpr->insertAfter(new CallExpr(PRIM_MOVE, unaliasTemp, new CallExpr(unaliasFn, refVar)));
-
-        // Replace all uses of 'useLhs' with 'unaliasTemp', except for the
-        // addr-of case we just created.
-        for_SymbolSymExprs(se, useLhs) {
-          if (CallExpr* call = toCallExpr(se->parentExpr)) {
-            if (call->isPrimitive(PRIM_ADDR_OF) == false) {
-              se->replace(new SymExpr(unaliasTemp));
-            }
-          }
-        }
-      }
+    // If replacing an init copy, we got to a user variable. Use an unalias
+    // call if possible
+    if (rhsFn->hasFlag(FLAG_INIT_COPY_FN) && unaliasFn != NULL) {
+      // BHARSH: It seems important that there's a temporary to store the
+      // result of the unaliasFn call. Otherwise we'll move into a variable
+      // that has multiplie uses, which seems to cause a variety of problems.
+      //
+      // In particular, I noticed that `changeRetToArgAndClone` would generate
+      // bad AST if I simply did this:
+      //   copyExpr->replace(new CallExpr(unaliasFn, refVar));
+      VarSymbol* unaliasTemp = newTemp("unaliasTemp", unaliasFn->retType);
+      callExpr->insertBefore(new DefExpr(unaliasTemp));
+      callExpr->insertAfter(new CallExpr(PRIM_MOVE, unaliasTemp, new CallExpr(unaliasFn, refVar)));
+      copyExpr->replace(new SymExpr(unaliasTemp));
+    } else {
+      copyExpr->replace(copyExpr->get(1)->remove());
     }
   }
 }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3579,6 +3579,8 @@ module ChapelArray {
   pragma "unalias fn"
   inline proc chpl__unalias(x: domain) {
     if x._unowned {
+      // We could add an autoDestroy here, but it wouldn't do anything for
+      // an unowned domain.
       pragma "no auto destroy" var ret = x;
       return ret;
     } else {
@@ -3689,7 +3691,12 @@ module ChapelArray {
   where x._value.isSliceArrayView() {
     // Intended to call chpl__initCopy
     pragma "no auto destroy" var ret = x;
+
+    // Since chpl__unalias replaces a initCopy(auto/initCopy()) the inner value
+    // needs to be auto-destroyed.
+    // TODO: Should this be inserted by the compiler?
     chpl__autoDestroy(x);
+
     return ret;
   }
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1063,12 +1063,21 @@ module ChapelBase {
 
   pragma "compiler generated"
   pragma "unalias fn"
-  inline proc chpl__unalias(ref x) { }
+  inline proc chpl__unalias(x) {
+    pragma "no copy" var ret = x;
+    return ret;
+  }
 
   pragma "unalias fn"
-  inline proc chpl__unalias(x:_iteratorClass) { }
+  inline proc chpl__unalias(x:_iteratorClass) {
+    pragma "no copy" var ret = x;
+    return ret;
+  }
   pragma "unalias fn"
-  inline proc chpl__unalias(const ref x:_iteratorRecord) { }
+  inline proc chpl__unalias(const ref x:_iteratorRecord) {
+    pragma "no copy" var ret = x;
+    return ret;
+  }
 
   inline proc chpl__maybeAutoDestroyed(x: numeric) param return false;
   inline proc chpl__maybeAutoDestroyed(x: enumerated) param return false;

--- a/modules/minimal/internal/ChapelBase.chpl
+++ b/modules/minimal/internal/ChapelBase.chpl
@@ -34,6 +34,9 @@ module ChapelBase {
 
   pragma "compiler generated"
   pragma "unalias fn"
-  inline proc chpl__unalias(ref x) { }
+  inline proc chpl__unalias(x) {
+    pragma "no copy" var ret = x;
+    return x;
+  }
 
 }


### PR DESCRIPTION
For array-views, we want chpl__unalias to create a type different from
the formal. This is more easily accomplished by turning chpl__unalias
into a returning function instead of one that modifies the formal
in-place.

The compiler modifications to support this change are fairly simple. We
now allow for the reduction of initCopy/autoCopy if the types differ and
there's an available chpl__unalias function. We then create new AST to
capture the result of chpl__unalias, and move the result into the
correct positions.

chpl__unalias functions now have to return something. Existing
chpl__unalias functions have been modified to include some path that
returns the formal without modifications. Otherwise, the chpl__unalias
functions for domains and arrays now invoke chpl__initCopy implicitly to
perform the deep-copy when necessary (e.g., for aliases).