### PR TITLE
Improve bulk-transfer for array-views

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -178,7 +178,7 @@ class ArrayViewRankChangeArr: BaseArr {
 
   inline proc chpl_rankChangeConvertDom(dims) {
     if dom.rank != dims.size {
-      compilerError("Called chpl_rankChangeConvertDom with incorrect rank. Got ", dims.size:string, ", expecting", dom.rank:string);
+      compilerError("Called chpl_rankChangeConvertDom with incorrect rank. Got ", dims.size:string, ", expecting ", dom.rank:string);
     }
     //
     // TODO: I worry that I'm being too fast and loose with domain
@@ -260,9 +260,9 @@ class ArrayViewRankChangeArr: BaseArr {
     if goodDims.size != arr.rank {
       compilerError("Error while composing view domain for rank-change view.");
     }
-    if _containsRankChange() {
-      var nextChange = arr._getRankChangeView();
-      return nextChange._viewHelper(goodDims);
+    if _containsRCRE() {
+      var nextView = arr._getRCREView();
+      return nextView._viewHelper(goodDims);
     } else {
       return {(...goodDims)};
     }
@@ -321,15 +321,17 @@ class ArrayViewRankChangeArr: BaseArr {
     }
   }
 
-  proc _containsRankChange() param {
+  proc _containsRCRE() param {
     if chpl__isArrayView(arr) {
-      return arr.isRankChangeArrayView() || arr._containsRankChange();
+      return arr.isRankChangeArrayView() ||
+             arr.isReindexArrayView() ||
+             arr._containsRCRE();
     } else {
       return false;
     }
   }
 
-  proc _getRankChangeView() {
+  proc _getRCREView() {
     return this;
   }
 }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -622,8 +622,9 @@ module ChapelArray {
     use Reflection;
     param isSlice = if canResolveMethod(arr, "isSliceArrayView") then arr.isSliceArrayView() else false;
     param isRankChange = if canResolveMethod(arr, "isRankChangeArrayView") then arr.isRankChangeArrayView() else false;
+    param isReindex = if canResolveMethod(arr, "isReindexArrayView") then arr.isReindexArrayView() else false;
 
-    return isSlice || isRankChange;
+    return isSlice || isRankChange || isReindex;
   }
 
   proc chpl__getViewDom(arr: []) {
@@ -1043,7 +1044,7 @@ module ChapelArray {
     pragma "no doc"
     proc this(args ...rank) where _validRankChangeArgs(args, _value.idxType) {
       var ranges = _getRankChangeRanges(args);
-      param newRank = ranges.size, stridable = chpl__anyStridable(ranges);
+      param newRank = ranges.size, stridable = chpl__anyStridable(ranges) || chpl__anyStridable(dims());
       var newRanges: newRank*range(idxType=_value.idxType, stridable=stridable);
       var newDistVal = _value.dist.dsiCreateRankChangeDist(newRank, args);
       var sameDist = (newDistVal == _value.dist);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2067,7 +2067,8 @@ module DefaultRectangular {
   */
   proc DefaultRectangularArr.doiBulkTransferStride(B, viewDom) {
     if debugDefaultDistBulkTransfer {
-      writeln("In DefaultRectangularArr.doiUseBulkTransferStride");
+      writeln();
+      writeln("In DefaultRectangularArr.doiBulkTransferStride");
     }
     var actual = chpl__getActualArray(B);
     if (this.dataChunk(0).locale.id != here.id

--- a/test/optimizations/bulkcomm/bharshbarg/arrayViews.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/arrayViews.chpl
@@ -1,0 +1,36 @@
+
+use util;
+
+proc main() {
+  var A, B : [1..10, 1..10] int;
+  var RE => A.reindex({1..100 by 10, 1..100 by 10});
+  write("Testing reindex...");
+  stridedAssign(RE, B);
+  stridedAssign(B, RE);
+  writeln("OK");
+
+  write("Testing slices of reindexes...");
+  const firstThree = (1..100 by 10) # 3;
+  stridedAssign(RE[firstThree, firstThree], B[1..3, 1..3]);
+  stridedAssign(B[1..3, 1..3], RE[firstThree, firstThree]);
+  writeln("OK");
+
+  write("Testing reindex of reindex...");
+  var MoreRE = RE.reindex({1..10, 1..10});
+  stridedAssign(MoreRE, B);
+  stridedAssign(B, MoreRE);
+  writeln("OK");
+
+  // rank changes
+  write("Testing rank-change of reindex...");
+  stridedAssign(RE[1,..], B[1,..]);
+  stridedAssign(B[1,..], RE[1,..]);
+  writeln("OK");
+
+  var rankChange => A[1,..];
+  var RCRE => rankChange.reindex({1..100 by 10});
+  write("Testing reindex of rank-change...");
+  stridedAssign(RCRE, B[1,..]);
+  stridedAssign(B[1,..], RCRE);
+  writeln("OK");
+}

--- a/test/optimizations/bulkcomm/bharshbarg/arrayViews.compopts
+++ b/test/optimizations/bulkcomm/bharshbarg/arrayViews.compopts
@@ -1,0 +1,1 @@
+-suseBulkTransferStride

--- a/test/optimizations/bulkcomm/bharshbarg/arrayViews.good
+++ b/test/optimizations/bulkcomm/bharshbarg/arrayViews.good
@@ -1,0 +1,5 @@
+Testing reindex...OK
+Testing slices of reindexes...OK
+Testing reindex of reindex...OK
+Testing rank-change of reindex...OK
+Testing reindex of rank-change...OK

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
@@ -348,9 +348,9 @@ proc schurComplement(blk, AD, BD, Rest) {
                 var h1 => Ab._value.dsiLocalSlice1((outerRange, innerRange)),
                     h3 => replB._value.dsiLocalSlice1((blkRange, innerRange));
                 for a in outerRange {
-                  assert(h2._value.oneDData); // fend off multi-ddata
+                  assert(chpl__getActualArray(h2).oneDData); // fend off multi-ddata
                   const
-                    h2dd = h2._value.dataChunk(0),
+                    h2dd = chpl__getActualArray(h2).dataChunk(0),
                     h2off = hoistOffset(h2, a, blkRange);
                   for w in blkRange  {
                     const h2aw = h2dd(h2off+w); // h2[a,w];
@@ -359,12 +359,12 @@ proc schurComplement(blk, AD, BD, Rest) {
                     // We are using tuples instead of objects because
                     // the generated code is more efficient, which is
                     // also a needed compiler optimization.
-                    assert(h1._value.oneDData); // fend off multi-ddata
-                    assert(h3._value.oneDData); // fend off multi-ddata
+                    assert(chpl__getActualArray(h1).oneDData); // fend off multi-ddata
+                    assert(chpl__getActualArray(h3).oneDData); // fend off multi-ddata
                     const
-                      h1dd  = h1._value.dataChunk(0),
+                      h1dd  = chpl__getActualArray(h1).dataChunk(0),
                       h1off = hoistOffset(h1, a, innerRange),
-                      h3dd  = h3._value.dataChunk(0),
+                      h3dd  = chpl__getActualArray(h3).dataChunk(0),
                       h3off = hoistOffset(h3, w, innerRange);
                     for b in innerRange do
                       // Ab[a,b] -= replA[a,w] * replB[w,b];
@@ -419,7 +419,7 @@ proc DimensionalArr.dsiLocalSlice1((sliceDim1, sliceDim2)) {
 }
 
 inline proc hoistOffset(A: [], i1, slice2) {
-  const d = A._value;
+  const d = chpl__getActualArray(A);
   compilerAssert(d.rank == 2);
   const result = d.origin + i1 * d.blk(1) - d.factoredOffs;
   return result;
@@ -1012,8 +1012,8 @@ proc replicateA(abIx, dim2) {
 
         var locReplA =>
           replA._value.localAdescs[lid1,fromLocId2].myStorageArr;
-        assert(locReplA._value.oneDData); // fend off multi-ddata
-        const locReplAdd = locReplA._value.dataChunk(0);
+        assert(chpl__getActualArray(locReplA).oneDData); // fend off multi-ddata
+        const locReplAdd = chpl__getActualArray(locReplA).dataChunk(0);
 
         // (A) copy from the local portion of A[1..n, dim2] into replA[..,..]
         /*local*/ {
@@ -1023,8 +1023,8 @@ proc replicateA(abIx, dim2) {
             const iEnd = min(iStart + blkSize - 1, n),
                   iRange = iStart..iEnd;
             var locAB => Ab._value.dsiLocalSlice1((iRange, dim2));
-            assert(locAB._value.oneDData); // fend off multi-ddata
-            const locABdd = locAB._value.dataChunk(0);
+            assert(chpl__getActualArray(locAB).oneDData); // fend off multi-ddata
+            const locABdd = chpl__getActualArray(locAB).dataChunk(0);
 
             // locReplA[iRange,..] = locAB[iRange, dim2];
             const jStart = dim2.alignedLow,
@@ -1055,8 +1055,8 @@ proc replicateB(abIx, dim1) {
 
         var locReplB =>
           replB._value.localAdescs[fromLocId1,lid2].myStorageArr;
-        assert(locReplB._value.oneDData); // fend off multi-ddata
-        const locReplBdd = locReplB._value.dataChunk(0);
+        assert(chpl__getActualArray(locReplB).oneDData); // fend off multi-ddata
+        const locReplBdd = chpl__getActualArray(locReplB).dataChunk(0);
 
         // (A) copy from the local portion of A[dim1, 1..n+1] into replB[..,..]
         /*local*/ {
@@ -1066,8 +1066,8 @@ proc replicateB(abIx, dim1) {
             const jEnd = min(jStart + blkSize - 1, n+1),
                   jRange = jStart..jEnd;
             var locAB => Ab._value.dsiLocalSlice1((dim1, jRange));
-            assert(locAB._value.oneDData); // fend off multi-ddata
-            const locABdd = locAB._value.dataChunk(0);
+            assert(chpl__getActualArray(locAB).oneDData); // fend off multi-ddata
+            const locABdd = chpl__getActualArray(locAB).dataChunk(0);
 
             // locReplB[..,jRange] = locAB[dim1, jRange];
             const iStart = dim1.alignedLow,
@@ -1177,7 +1177,7 @@ proc gaxpyMinus(A: [],
 proc ensureDR(value, param msg) {
   proc etest(type t) param where t : DefaultRectangularArr return true;
   proc etest(type t) param return false;
-  compilerAssert(etest(value.type), "ensureDR ", msg, 2);
+  compilerAssert(etest(chpl__getActualArray(value).type), "ensureDR ", msg, 2);
 }
 
 proc makeLocalCopyOfAb() {


### PR DESCRIPTION
This commit implements the following methods on ArrayViewReindex:
- chpl_reindexConvertDom
- _getViewDom
- _viewHelper

These methods allow for reindexes to be bulk-transferred. In support of
this change, the following functions were modified:
- _containsRankChange --> _containsRCRE
- _getRankChangeView  --> _getRCREView

Here 'RCRE' stands for "RankChange/REindex". These two kinds of
ArrayViews need to be able to handle RankChanges and Reindexes further
down a view stack. We don't care about slices further down the stack
because the dimensions at the top are already sliced correctly.

This commit also implements a number of bulk-transfer interface methods
on ArrayViewReindex, much like the other ArrayViews.

The hpl.hpcc2012 test was modified to avoid compile-time errors, but
instead now encounters execution-time failures.