### PR TITLE
Fix shape mismatch failures

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1544,6 +1544,7 @@ proc BlockArr.doiBulkTransfer(B, viewDom) {
   if debugBlockDistBulkTransfer then resetCommDiagnostics();
 
   const equalDoms = (this.dom.whole == actual.dom.whole) &&
+                    (actDom == viewDom) &&
                     (this.dom.dist.dsiEqualDMaps(actual.dom.dist));
 
   // Use zippered iteration to piggyback data movement with the remote


### PR DESCRIPTION
Check if view domains are equivalent, otherwise the views may refer to different valid locales and the 'equalDoms' section will fail.