### PR TITLE
Optimize ArrayView accesses for DefaultRectangular

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1066,41 +1066,6 @@ proc BlockArr.dsiDestroyArr(isslice:bool) {
   }
 }
 
-inline proc _remoteAccessData.getDataIndex(param stridable, ind: rank*idxType) {
-  // modified from DefaultRectangularArr.getDataIndex
-  if stridable {
-    var sum = origin;
-    for param i in 1..rank do
-      sum += (ind(i) - off(i)) * blk(i) / abs(str(i)):idxType;
-    if defRectSimpleDData then {
-      return sum;
-    } else {
-      if mdNumChunks == 1 {
-        return (0, sum);
-      } else {
-        const chunk = mdInd2Chunk(ind(mdParDim));
-        return (chunk, sum - mData(chunk).dataOff);
-      }
-    }
-  } else {
-    var sum = if earlyShiftData then 0:idxType else origin;
-    for param i in 1..rank do
-      sum += ind(i) * blk(i);
-    if !earlyShiftData then sum -= factoredOffs;
-    if defRectSimpleDData {
-      return sum;
-    }
-    else {
-      if mdNumChunks == 1 {
-        return (0, sum);
-      } else {
-        const chunk = mdInd2Chunk(ind(mdParDim));
-        return (chunk, sum - mData(chunk).dataOff);
-      }
-    }
-  }
-}
-
 inline proc BlockArr.dsiLocalAccess(i: rank*idxType) ref {
   return myLocArr.this(i);
 }
@@ -1154,7 +1119,7 @@ proc BlockArr.nonLocalAccess(i: rank*idxType) ref {
       pragma "no copy" pragma "no auto destroy" var myLocRAD = myLocArr.locRAD;
       pragma "no copy" pragma "no auto destroy" var radata = myLocRAD.RAD;
       if radata(rlocIdx).shiftedDataChunk(0) != nil {
-        var dataIdx = radata(rlocIdx).getDataIndex(myLocArr.stridable, i);
+        var dataIdx = radata(rlocIdx).getBlockDataIndex(myLocArr.stridable, i);
         return radata(rlocIdx).shiftedDataElem(dataIdx);
       }
     }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1164,7 +1164,7 @@ proc StencilArr.nonLocalAccess(i: rank*idxType) ref {
       pragma "no copy" pragma "no auto destroy" var myLocRAD = myLocArr.locRAD;
       pragma "no copy" pragma "no auto destroy" var radata = myLocRAD.RAD;
       if radata(rlocIdx).shiftedDataChunk(0) != nil {
-        var dataIdx = radata(rlocIdx).getDataIndex(myLocArr.stridable, i);
+        var dataIdx = radata(rlocIdx).getBlockDataIndex(myLocArr.stridable, i);
         return radata(rlocIdx).shiftedDataElem(dataIdx);
       }
     }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -106,14 +106,12 @@ class ArrayViewRankChangeArr: BaseArr {
     }
   }
 
+  // TODO: We seem to run into compile-time bugs when using multiple yields.
+  // For now, work around them by using an if-expr
   iter these(param tag: iterKind) ref where tag == iterKind.standalone {
     for i in privDom.these(tag) {
-      if shouldUseIndexCache() {
-        const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
-        yield indexCache.shiftedDataElem(dataIdx);
-      } else {
-        yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
-      }
+      yield if shouldUseIndexCache() then indexCache.shiftedDataElem(indexCache.getBlockDataIndex(dom.stridable, i))
+            else arr.dsiAccess(chpl_rankChangeConvertIdx(i));
     }
   }
 

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -96,13 +96,25 @@ class ArrayViewRankChangeArr: BaseArr {
   // standard iterators
   //
   iter these() ref {
-    for i in privDom do
-      yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
+    for i in privDom {
+      if shouldUseIndexCache() {
+        const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+        yield indexCache.shiftedDataElem(dataIdx);
+      } else {
+        yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
+      }
+    }
   }
 
   iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-    for i in privDom.these(tag) do
-      yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
+    for i in privDom.these(tag) {
+      if shouldUseIndexCache() {
+        const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+        yield indexCache.shiftedDataElem(dataIdx);
+      } else {
+        yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
+      }
+    }
   }
 
   iter these(param tag: iterKind) where tag == iterKind.leader {
@@ -115,7 +127,12 @@ class ArrayViewRankChangeArr: BaseArr {
   iter these(param tag: iterKind, followThis) ref
     where tag == iterKind.follower {
     for i in privDom.these(tag, followThis) {
-      yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
+      if shouldUseIndexCache() {
+        const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+        yield indexCache.shiftedDataElem(dataIdx);
+      } else {
+        yield arr.dsiAccess(chpl_rankChangeConvertIdx(i));
+      }
     }
   }
 

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -93,13 +93,25 @@ module ArrayViewReindex {
     // standard iterators
     //
     iter these() ref {
-          for i in privDom do
-            yield arr.dsiAccess(chpl_reindexConvertIdx(i));
+      for i in privDom {
+        if shouldUseIndexCache() {
+          const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+          yield indexCache.shiftedDataElem(dataIdx);
+        } else {
+          yield arr.dsiAccess(chpl_reindexConvertIdx(i));
+        }
+      }
     }
 
     iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-      for i in privDom.these(tag) do
-        yield arr.dsiAccess(chpl_reindexConvertIdx(i));
+      for i in privDom.these(tag) {
+        if shouldUseIndexCache() {
+          const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+          yield indexCache.shiftedDataElem(dataIdx);
+        } else {
+          yield arr.dsiAccess(chpl_reindexConvertIdx(i));
+        }
+      }
     }
 
     iter these(param tag: iterKind) where tag == iterKind.leader {
@@ -112,7 +124,12 @@ module ArrayViewReindex {
     iter these(param tag: iterKind, followThis) ref
       where tag == iterKind.follower {
       for i in privDom.these(tag, followThis) {
-        yield arr.dsiAccess(chpl_reindexConvertIdx(i));
+        if shouldUseIndexCache() {
+          const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+          yield indexCache.shiftedDataElem(dataIdx);
+        } else {
+          yield arr.dsiAccess(chpl_reindexConvertIdx(i));
+        }
       }
     }
 

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -32,6 +32,27 @@ class ArrayViewSliceArr: BaseArr {
   const _ArrPid;
   const _ArrInstance;
 
+  const indexCache = buildIndexCache();
+
+  proc shouldUseIndexCache() param {
+    return _ArrInstance.isDefaultRectangular() &&
+           defRectSimpleDData;
+  }
+
+  // No modification of the index cache is necessary or a slice because the
+  // index set and rank remain the same.
+  proc buildIndexCache() {
+    if shouldUseIndexCache() {
+      if (chpl__isArrayView(_ArrInstance)) {
+        return _ArrInstance.indexCache.toSlice(dom);
+      } else {
+        return _ArrInstance.dsiGetRAD().toSlice(dom);
+      }
+    } else {
+      return false;
+    }
+  }
+
   inline proc privDom {
     if _isPrivatized(dom) {
       return chpl_getPrivatizedCopy(dom.type, _DomPid);
@@ -129,19 +150,34 @@ class ArrayViewSliceArr: BaseArr {
 
   inline proc dsiAccess(i) ref {
     checkBounds(i);
-    return arr.dsiAccess(i);
+    if shouldUseIndexCache() {
+      const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+      return indexCache.shiftedDataElem(dataIdx);
+    } else {
+      return arr.dsiAccess(i);
+    }
   }
 
   inline proc dsiAccess(i)
   where !shouldReturnRvalueByConstRef(eltType) {
     checkBounds(i);
-    return arr.dsiAccess(i);
+    if shouldUseIndexCache() {
+      const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+      return indexCache.shiftedDataElem(dataIdx);
+    } else {
+      return arr.dsiAccess(i);
+    }
   }
 
   inline proc dsiAccess(i) const ref
   where shouldReturnRvalueByConstRef(eltType) {
     checkBounds(i);
-    return arr.dsiAccess(i);
+    if shouldUseIndexCache() {
+      const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
+      return indexCache.shiftedDataElem(dataIdx);
+    } else {
+      return arr.dsiAccess(i);
+    }
   }
 
   proc dsiTargetLocales() {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -706,6 +706,10 @@ module DefaultRectangular {
     }
   }
 
+  inline proc _remoteAccessData.getBlockDataIndex(param stridable, ind : idxType) {
+    return this.getBlockDataIndex(stridable, chpl__tuplify(ind));
+  }
+
   inline proc _remoteAccessData.getBlockDataIndex(param stridable, ind: rank*idxType) {
       param chunkify = !defRectSimpleDData;
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -803,7 +803,11 @@ module DefaultRectangular {
 
     for param i in 1..rank {
       const shift = this.blk(i) * (newDom.dsiDim(i).low - this.off(i)) / abs(this.str(i)) : rad.idxType;
-      rad.origin += if this.str(i) > 0 then shift else -shift;
+      if this.str(i) > 0 {
+        rad.origin += shift;
+      } else {
+        rad.origin -= shift;
+      }
 
       const mult = (newDom.dsiDim(i).stride / this.str(i)) : rad.idxType;
       rad.blk(i) = this.blk(i) * mult;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -780,20 +780,21 @@ module DefaultRectangular {
     compilerAssert(defRectSimpleDData);
     compilerAssert(this.rank == newDom.rank);
     type idxSignedType = chpl__signedType(newDom.idxType);
-    var rad : _remoteAccessData(eltType, newDom.rank, idxType, newDom.stridable, blkChanged);
+    var rad : _remoteAccessData(eltType, newDom.rank, idxType, newDom.stridable, newDom.stridable || this.blkChanged);
     rad.data        = this.data;
-    rad.shiftedData = this.shiftedData;
-    rad.blk         = this.blk;
+    rad.shiftedData = if newDom.stridable then this.data else this.shiftedData;
     rad.origin      = this.origin:newDom.idxType;
     for param i in 1..rank {
       rad.off(i) = newDom.dsiDim(i).low;
       rad.str(i) = newDom.dsiDim(i).stride;
-      const shift = blk(i) * (newDom.dsiDim(i).low - this.off(i)) / abs(this.str(i)) : newDom.idxType;
+      const shift = this.blk(i) * (newDom.dsiDim(i).low - this.off(i)) / abs(this.str(i)) : newDom.idxType;
       if this.str(i) > 0 {
         rad.origin += shift;
       } else {
         rad.origin -= shift;
       }
+      const mult = (newDom.dsiDim(i).stride / this.str(i)) : newDom.idxType;
+      rad.blk(i) = this.blk(i) * mult;
     }
     for param i in 1..rank do {
       rad.factoredOffs = rad.factoredOffs + rad.blk(i) * rad.off(i);
@@ -814,7 +815,7 @@ module DefaultRectangular {
     type idxSignedType = chpl__signedType(newDom.idxType);
     var rad : _remoteAccessData(eltType, newDom.rank, idxType, newDom.stridable, blkChanged);
     rad.data        = this.data;
-    rad.shiftedData = this.shiftedData;
+    rad.shiftedData = if newDom.stridable then this.data else this.shiftedData;
     rad.origin      = this.origin:newDom.idxType;
     for param i in 1..rank {
       rad.off(i) = newDom.dsiDim(i).low;
@@ -842,7 +843,7 @@ module DefaultRectangular {
     const collapsedDims = chpl__tuplify(cd);
     var rad : _remoteAccessData(eltType, newDom.rank, idxType, newDom.stridable, true);
     rad.data        = this.data;
-    rad.shiftedData = this.shiftedData;
+    rad.shiftedData = if newDom.stridable then this.data else this.shiftedData;
     rad.origin      = this.origin:newDom.idxType;
     type idxSignedType = chpl__signedType(newDom.idxType);
     var curDim = 1;


### PR DESCRIPTION
We can re-use the RAD record to precompute the correct
off/blk/str/origin info such that we can index into a ddata pointer
without doing the index translation normally requred by the reindex and
rank-change ArrayViews. The RAD record was chosen to avoid creating
another very similar record. Remoteness has nothing to do with this problem.

The helper functions (toReindex, toRankChange, toSlice) are based off of
the old dsi* functions involving those views.

Moves the BlockDist RAD accessor method into DefaultRectangular for
code-reuse.