### PR TITLE
Improve slice indexing performance

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -48,7 +48,7 @@ class ArrayViewRankChangeArr: BaseArr {
         if _ArrInstance.isSliceArrayView() && !_ArrInstance._containsRCRE() {
           // Only slices below in the view stack, which won't have built up
           // an indexCache.
-          return _ArrInstance._getActualArray().dsiGetRAD().toRankChange(dom, collapsedDim, idx);
+          return _ArrInstance._getActualArray().dsiGetRAD().toSlice(_ArrInstance.dom).toRankChange(dom, collapsedDim, idx);
         } else {
           return _ArrInstance.indexCache.toRankChange(dom, collapsedDim, idx);
         }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -45,7 +45,13 @@ class ArrayViewRankChangeArr: BaseArr {
   proc buildIndexCache() {
     if shouldUseIndexCache() {
       if (chpl__isArrayView(_ArrInstance)) {
-        return _ArrInstance.indexCache.toRankChange(dom, collapsedDim, idx);
+        if _ArrInstance.isSliceArrayView() && !_ArrInstance._containsRCRE() {
+          // Only slices below in the view stack, which won't have built up
+          // an indexCache.
+          return _ArrInstance._getActualArray().dsiGetRAD().toRankChange(dom, collapsedDim, idx);
+        } else {
+          return _ArrInstance.indexCache.toRankChange(dom, collapsedDim, idx);
+        }
       } else {
         return _ArrInstance.dsiGetRAD().toRankChange(dom, collapsedDim, idx);
       }

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -42,7 +42,13 @@ module ArrayViewReindex {
     proc buildIndexCache() {
       if shouldUseIndexCache() {
         if (chpl__isArrayView(_ArrInstance)) {
-          return _ArrInstance.indexCache.toReindex(dom);
+          if _ArrInstance.isSliceArrayView() && !_ArrInstance._containsRCRE() {
+            // Only slices below in the view stack, which won't have built up
+            // an indexCache.
+            return _ArrInstance._getActualArray().dsiGetRAD().toReindex(dom);
+          } else {
+            return _ArrInstance.indexCache.toReindex(dom);
+          }
         } else {
           return _ArrInstance.dsiGetRAD().toReindex(dom);
         }

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -45,7 +45,7 @@ module ArrayViewReindex {
           if _ArrInstance.isSliceArrayView() && !_ArrInstance._containsRCRE() {
             // Only slices below in the view stack, which won't have built up
             // an indexCache.
-            return _ArrInstance._getActualArray().dsiGetRAD().toReindex(dom);
+            return _ArrInstance._getActualArray().dsiGetRAD().toSlice(_ArrInstance.dom).toReindex(dom);
           } else {
             return _ArrInstance.indexCache.toReindex(dom);
           }

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -36,6 +36,7 @@ class ArrayViewSliceArr: BaseArr {
 
   proc shouldUseIndexCache() param {
     return _ArrInstance.isDefaultRectangular() &&
+           _containsRCRE() &&
            defRectSimpleDData;
   }
 


### PR DESCRIPTION
Only use index optimization for ArrayViewSlice if the view stack contains a rank-change or reindex.