### PR TITLE
numa fixes

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1479,7 +1479,7 @@ proc BlockArr.doiUseBulkTransfer(B) {
   if this.rank != B.rank then return false;
   return defRectSimpleDData
          || dom == B._value.dom
-         || (oneDData && B._value.oneDData);
+         || (oneDData && chpl__getActualArray(B).oneDData);
 }
 
 proc BlockArr.doiUseBulkTransferStride(B) {
@@ -1496,7 +1496,7 @@ proc BlockArr.doiUseBulkTransferStride(B) {
   //
   if this.rank != B.rank then return false;
   return defRectSimpleDData
-         || (oneDData && B._value.oneDData);
+         || (oneDData && chpl__getActualArray(B).oneDData);
 }
 
 proc BlockArr.doiBulkTransfer(B, viewDom) {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1097,7 +1097,7 @@ proc CyclicArr.doiUseBulkTransferStride(B) {
   //
   if this.rank != B.rank then return false;
   return defRectSimpleDData
-         || (oneDData && B._value.oneDData);
+         || (oneDData && chpl__getActualArray(B).oneDData);
 }
 
 //For assignments of the form: "Cyclic = any" 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1706,7 +1706,7 @@ proc StencilArr.doiUseBulkTransfer(B) {
   if this.rank != B.rank then return false;
   return defRectSimpleDData
          || dom == B._value.dom
-         || (oneDData && B._value.oneDData);
+         || (oneDData && chpl__getActualArray(B).oneDData);
 }
 
 proc StencilArr.doiUseBulkTransferStride(B) {
@@ -1723,7 +1723,7 @@ proc StencilArr.doiUseBulkTransferStride(B) {
   //
   if this.rank != B.rank then return false;
   return defRectSimpleDData
-         || (oneDData && B._value.oneDData);
+         || (oneDData && chpl__getActualArray(B).oneDData);
 }
 
 proc StencilArr.doiBulkTransfer(B, viewDom) {

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -114,8 +114,8 @@ class ArrayViewRankChangeArr: BaseArr {
 
   // TODO: We seem to run into compile-time bugs when using multiple yields.
   // For now, work around them by using an if-expr
-  iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-    for i in privDom.these(tag) {
+  iter these(param tag: iterKind) ref where tag == iterKind.standalone && !localeModelHasSublocales {
+    forall i in privDom {
       yield if shouldUseIndexCache() then indexCache.shiftedDataElem(indexCache.getBlockDataIndex(dom.stridable, i))
             else arr.dsiAccess(chpl_rankChangeConvertIdx(i));
     }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -115,7 +115,7 @@ class ArrayViewRankChangeArr: BaseArr {
   // TODO: We seem to run into compile-time bugs when using multiple yields.
   // For now, work around them by using an if-expr
   iter these(param tag: iterKind) ref where tag == iterKind.standalone && !localeModelHasSublocales {
-    forall i in privDom {
+    for i in privDom.these(tag) {
       yield if shouldUseIndexCache() then indexCache.shiftedDataElem(indexCache.getBlockDataIndex(dom.stridable, i))
             else arr.dsiAccess(chpl_rankChangeConvertIdx(i));
     }

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -110,7 +110,7 @@ module ArrayViewReindex {
     }
 
     iter these(param tag: iterKind) ref where tag == iterKind.standalone && !localeModelHasSublocales {
-      forall i in privDom {
+      for i in privDom.these(tag) {
         if shouldUseIndexCache() {
           const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
           yield indexCache.shiftedDataElem(dataIdx);

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -109,8 +109,8 @@ module ArrayViewReindex {
       }
     }
 
-    iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-      for i in privDom.these(tag) {
+    iter these(param tag: iterKind) ref where tag == iterKind.standalone && !localeModelHasSublocales {
+      forall i in privDom {
         if shouldUseIndexCache() {
           const dataIdx = indexCache.getBlockDataIndex(dom.stridable, i);
           yield indexCache.shiftedDataElem(dataIdx);

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -101,7 +101,7 @@ class ArrayViewSliceArr: BaseArr {
   }
 
   iter these(param tag: iterKind) ref where tag == iterKind.standalone && !localeModelHasSublocales {
-    forall i in privDom do yield arr.dsiAccess(i);
+    for i in privDom.these(tag) do yield arr.dsiAccess(i);
   }
 
   iter these(param tag: iterKind) where tag == iterKind.leader {

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -100,9 +100,8 @@ class ArrayViewSliceArr: BaseArr {
       yield arr.dsiAccess(i);
   }
 
-  iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-    for i in privDom.these(tag) do
-      yield arr.dsiAccess(i);
+  iter these(param tag: iterKind) ref where tag == iterKind.standalone && !localeModelHasSublocales {
+    forall i in privDom do yield arr.dsiAccess(i);
   }
 
   iter these(param tag: iterKind) where tag == iterKind.leader {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1957,7 +1957,7 @@ module DefaultRectangular {
 
     } else if arr.isDefaultRectangular() && !chpl__isArrayView(arr) &&
               _isSimpleIoType(arr.eltType) && f.binary() &&
-              isNative && arr.isDataContiguous(dom) {
+              isNative && arr.isDataContiguous(dom) && defRectSimpleDData {
       // If we can, we would like to read/write the array as a single write op
       // since _ddata is just a pointer to the memory location we just pass
       // that along with the size of the array. This is only possible when the
@@ -2066,11 +2066,16 @@ module DefaultRectangular {
     // With multi-ddata, at least for now if the arrays aren't chunked
     // exactly the same way we don't do direct bulk transfer.
     //
-    if this.rank != B.rank then return false;
-    return (defRectSimpleDData
-            || (mdParDim == B._value.mdParDim
-                && mdNumChunks == B._value.mdNumChunks
-                && mdRLen == B._value.mdRLen));
+    if this.rank != B.rank {
+      return false;
+    } else if defRectSimpleDData {
+      return true;
+    } else {
+      const actual = chpl__getActualArray(B);
+      return mdParDim == actual.mdParDim
+      && mdNumChunks == actual.mdNumChunks
+      && mdRLen == actual.mdRLen;
+    }
   }
 
   proc DefaultRectangularArr.doiUseBulkTransferStride(B) {

--- a/test/arrays/gbt/multi-ddata/impl/chunking.chpl
+++ b/test/arrays/gbt/multi-ddata/impl/chunking.chpl
@@ -52,24 +52,24 @@ proc reportChunking(what, A) {
     writeln('----');
     A.displayRepresentation();
     writeln(' dom.dsiDims() ', A._value.dom.dsiDims(),
-            ', stridable ', A._value.stridable);
+            ', stridable ', chpl__getActualArray(A).stridable);
     writeln('----');
   }
 
-  for i in A.domain.dim(A._value.mdParDim) do
-    write(' ', A._value.mdInd2Chunk(i));
+  for i in A.domain.dim(chpl__getActualArray(A).mdParDim) do
+    write(' ', chpl__getActualArray(A).mdInd2Chunk(i));
   writeln();
 
-  for iChunk in 0..#A._value.mdNumChunks do
-    write(if iChunk == 0 then ' ' else ', ', A._value.mData(iChunk).pdr);
+  for iChunk in 0..#chpl__getActualArray(A).mdNumChunks do
+    write(if iChunk == 0 then ' ' else ', ', chpl__getActualArray(A).mData(iChunk).pdr);
   writeln();
 
   if verbose {
     write(' -->');
-    for iChunk in 0..#A._value.mdNumChunks do
+    for iChunk in 0..#chpl__getActualArray(A).mdNumChunks do
       write(' ',
-            _computeBlock(A._value.mdRLen, A._value.mdNumChunks, iChunk,
-                          (A._value.mdRHi - A._value.mdRLo) / A._value.mdRStr,
+            _computeBlock(chpl__getActualArray(A).mdRLen, chpl__getActualArray(A).mdNumChunks, iChunk,
+                          (chpl__getActualArray(A).mdRHi - chpl__getActualArray(A).mdRLo) / chpl__getActualArray(A).mdRStr,
                           0, 0));
     writeln();
   }

--- a/test/memory/sungeun/refCount/domainMaps.lm-numa.good
+++ b/test/memory/sungeun/refCount/domainMaps.lm-numa.good
@@ -65,10 +65,10 @@ total:
 Replicated Dist
 ===============
 Copy of domain map:
-	368 bytes leaked
+	0 bytes leaked
 	0 private objects leaked
 Return domain map:
-	368 bytes leaked
+	0 bytes leaked
 	0 private objects leaked
 Create domain:
 	0 bytes leaked
@@ -77,4 +77,4 @@ Create domain and array:
 	0 bytes leaked
 	0 private objects leaked
 total:
-	1104 bytes leaked
+	0 bytes leaked


### PR DESCRIPTION
Concerns:
- There's a compiler bug in miniMD where the compiler infers the incorrect type in resolution because an autoCopy of an ArrayView is later inserted (resulting in a non-view). I think this is likely poking some untested and weird behavior in our reduction implementation.
- I do not know what performance testing will look like. I did not implement the indexing-cache for multi-ddata since at this time I'm not sure how it should work.

Basically, these changes should save us from the hundreds/thousands of failures we would otherwise encounter upon merging into chapel-lang/master.