### PR TITLE
Fix a handful of ReplicatedDist errors

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -616,6 +616,11 @@ module ChapelLocale {
     return blockedTasks;
   }
 
+  pragma "no doc"
+  proc <(a: locale, b: locale) {
+    return a.id < b.id;
+  }
+
 //########################################################################}
 
   //

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -616,11 +616,6 @@ module ChapelLocale {
     return blockedTasks;
   }
 
-  pragma "no doc"
-  proc <(a: locale, b: locale) {
-    return a.id < b.id;
-  }
-
 //########################################################################}
 
   //

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1791,6 +1791,10 @@ module DefaultRectangular {
   }
 
   proc chpl_serialReadWriteRectangular(f, arr, dom) {
+    chpl_serialReadWriteRectangularHelper(f, arr, dom);
+  }
+
+  proc chpl_serialReadWriteRectangularHelper(f, arr, dom) {
     param rank = arr.rank;
     type idxType = arr.idxType;
     type idxSignedType = chpl__signedType(idxType);


### PR DESCRIPTION
- Add 'idxType' and 'rank' parenthese-less methods on ReplicatedArr to avoid
  compile-time failures.
- Sort the targetLocDom and targetLocales in more places for reliable output.
- Add a Replicated-specific overload for chpl_serialReadWriteRectangular
  because ReplicatedArr wants to print its info for each locale. The general
  catch-all in DefaultRectangular was split into a helper function to make this
  easier.
- Add a "<" overload for the 'locale' object to allow the sorted iterator to
  work on an associative array of locales.

With these changes there will be roughly 18 failures in the dist-replicated
testing configuration with incorrect program output. They fall into the
following categories:
1) 'internal error: compiler generated error' - I haven't dug much into these
   yet, but past experience tells me this is likely an iterator bug.
2) Incorrect values in the array - I'm pretty sure the problem is that the
   ArrayView iterators iterate over 'privDom', which will not be distributed in
   the rank-change and reindex cases.
3) Higher communication counts - the cause is unknown at this time, but I'd
   prefer to solve the correctness issues before tackling these. It may be
   related to the non-distributed 'privDom'.