### PR TITLE
Improve rank-change DomainView performance

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -670,7 +670,7 @@ module ChapelArray {
   // 'arr' can be a full-fledged array type or a class that inherits from
   // BaseArr
   //
-  proc chpl__isDROrDRView(arr) param {
+  proc chpl__isDROrDRView(arr) param where isArray(arr) || arr : BaseArr {
     const value = if isArray(arr) then arr._value else arr;
     param isDR = value.isDefaultRectangular();
     param isDRView = chpl__isArrayView(value) && chpl__getActualArray(value).isDefaultRectangular();
@@ -678,6 +678,36 @@ module ChapelArray {
   }
   //
   // End of array-view utility functions
+  //
+
+  //
+  // DomainView utility functions
+  //
+  proc chpl__isDomainView(dom) param {
+    const value = if isDomain(dom) then dom._value else dom;
+
+    param isSlice      = value.isSliceDomainView();
+    param isRankChange = value.isRankChangeDomainView();
+    param isReindex    = value.isReindexDomainView();
+
+    return isSlice || isRankChange || isReindex;
+  }
+
+  proc chpl__getActualDomain(dom) {
+    var value = if isDomain(dom) then dom._value else dom;
+    var ret = if chpl__isDomainView(value) then value._getActualDomain() else value;
+    return ret;
+  }
+
+  proc chpl__isDROrDRView(dom) param where isDomain(dom) || dom : BaseDom {
+    const value = if isDomain(dom) then dom._value else dom;
+    param isDR  = value.isDefaultRectangular();
+    param isDRView = chpl__isDomainView(value) && chpl__getActualDomain(value).isDefaultRectangular();
+    return isDR || isDRView;
+  }
+
+  //
+  // End of DomainView utility functions
   //
 
   proc chpl__isRectangularDomType(type domainType) param {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -316,6 +316,12 @@ module ChapelDistribution {
     //proc dsiDestroyDom() { }
 
     proc dsiDisplayRepresentation() { writeln("<no way to display representation>"); }
+
+    proc isDefaultRectangular() param return false;
+
+    proc isSliceDomainView() param return false; // likely unnecessary?
+    proc isRankChangeDomainView() param return false;
+    proc isReindexDomainView() param return false;
   }
   
   class BaseRectangularDom : BaseDom {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -110,6 +110,8 @@ module DefaultRectangular {
     proc linksDistribution() param return false;
     proc dsiLinksDistribution()     return false;
 
+    proc isDefaultRectangular() param return true;
+
     proc DefaultRectangularDom(param rank, type idxType, param stridable, dist) {
       this.dist = dist;
     }


### PR DESCRIPTION
Calling ``downIdxToUpIdx``, or some similar translation function,
on each yielded indice is costly. Since the ``updom`` is a
DefaultRectangular, we can simply iterate over that instead
if ``downdom`` is a DefaultRectangularDom (or a view over one).
Inlining the ``downIdxToUpIdx`` function does help a little
bit though.

Adds the following helper functions/methods (similar to the
ArrayView variants):
- chpl__isDROrDRView
- baseDom.isSliceDomainView
- baseDom.isRankChangeDomainView
- baseDom.isReindexDomainView
- _getActualDomain
- chpl__isDomainView
- chpl__getActualDomain
- BaseDom.isDefaultRectangular