### PR TITLE
Fix some memory leaks for rank-changed arrays

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8925,10 +8925,9 @@ static void insertUnrefForArrayReturn(FnSymbol* fn) {
 
           CallExpr* unrefCall = new CallExpr("chpl__unref", tmp);
           call->insertAtTail(unrefCall);
-          FnSymbol* unrefFn = resolveNormalCall(unrefCall);
-          resolveFns(unrefFn);
-
-          if (unrefFn->retType == tmp->typeInfo()) {
+          FnSymbol* unrefFn = NULL;
+          unrefFn = resolveNormalCall(unrefCall, true);
+          if (unrefFn == NULL) {
             // If the types are equal, we must be dealing with a non-view
             // array, so we can remove the useless unref call.
             unrefCall->replace(origRHS->copy());
@@ -8937,6 +8936,9 @@ static void insertUnrefForArrayReturn(FnSymbol* fn) {
             tmp->defPoint->remove();
             init_unref_tmp->remove();
             INT_ASSERT(unrefCall->inTree() == false);
+          } else {
+            unrefFn = resolveNormalCall(unrefCall);
+            resolveFns(unrefFn);
           }
         }
       }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8928,8 +8928,8 @@ static void insertUnrefForArrayReturn(FnSymbol* fn) {
           FnSymbol* unrefFn = NULL;
           unrefFn = resolveNormalCall(unrefCall, true);
           if (unrefFn == NULL) {
-            // If the types are equal, we must be dealing with a non-view
-            // array, so we can remove the useless unref call.
+            // If the call cannot be resolved, we must be dealing with a
+            // non-view array, so we can remove the useless unref call.
             unrefCall->replace(origRHS->copy());
 
             // Remove now-useless AST

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -116,7 +116,8 @@ module ArrayViewRankChange {
                                         _ArrPid=downarr._pid,
                                         _ArrInstance=downarr._instance,
                                         collapsedDim=collapsedDim,
-                                        idx=idx);
+                                        idx=idx,
+                                        ownsArrInstance=true);
     }
 
     // TODO: Use delegation feature for these?
@@ -404,6 +405,8 @@ module ArrayViewRankChange {
     // accessing the array's ddata to avoid indirection overheads
     // through the array field above.
     const indexCache = buildIndexCache();
+
+    const ownsArrInstance = false;
 
 
     //
@@ -791,8 +794,10 @@ module ArrayViewRankChange {
       return this;
     }
 
-    proc dsiDestroyArr() {
-      _delete_arr(_ArrInstance, _isPrivatized(_ArrInstance));
+    proc dsiDestroyArr(isalias:bool) {
+      if ownsArrInstance {
+        _delete_arr(_ArrInstance, _isPrivatized(_ArrInstance));
+      }
     }
   }  // ArrayViewRankChangeArr
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3821,12 +3821,6 @@ module ChapelArray {
     return ret;
   }
 
-  // Intended to return whatever it gets without copying
-  pragma "no copy return"
-  inline proc chpl__unref(x: []) {
-    pragma "no copy" var ret = x;
-    return ret;
-  }
 
 
   // see comment on chpl__unalias for domains


### PR DESCRIPTION
In short, this PR:
- restores the copy-out behavior for rank-changed arrays
- frees the inner instance of the rank-changed array if
  it was created by dsiBuildArray